### PR TITLE
fix: fix json import

### DIFF
--- a/nodejs/.gitignore
+++ b/nodejs/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib/
 docs/
+src/version_dist.ts

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@speechify/api-sdk",
 	"version": "1.0.0",
-	"description": "",
+	"description": "Official Speechify AI API SDK",
 	"main": "index.js",
 	"type": "module",
 	"files": [

--- a/nodejs/scripts/build.sh
+++ b/nodejs/scripts/build.sh
@@ -21,14 +21,22 @@ echo Compilation successful!
 
 # After building the package, replace version.ts importing from package.json with the "static" version
 echo Substituting materialized version export
+
 mv lib/cjs/src/version_dist.js lib/cjs/src/version.js
 mv lib/cjs/src/version_dist.js.map lib/cjs/src/version.js.map
 rm lib/cjs/src/version_dist.d.ts
+sed -i '' 's/version_dist.js/version.js/g' lib/cjs/src/version.js.map
+sed -i '' 's/version_dist.js.map/version.js.map/g' lib/cjs/src/version.js
+
 mv lib/esm/src/version_dist.js lib/esm/src/version.js
 mv lib/esm/src/version_dist.js.map lib/esm/src/version.js.map
 rm lib/esm/src/version_dist.d.ts
+sed -i '' 's/version_dist.js/version.js/g' lib/esm/src/version.js.map
+sed -i '' 's/version_dist.js.map/version.js.map/g' lib/esm/src/version.js
 
 echo Cleaning up...
 
-rm -rf lib/{cjs,esm}/**/{*.test.*,test-helper.*,*.tsbuildinfo} > /dev/null 2>&1
+rm -rf lib/{cjs,esm}/**/{*.test.*,test-helper.*} > /dev/null 2>&1
 rm -rf lib/{cjs,esm}/*.tsbuildinfo > /dev/null 2>&1
+
+echo All done

--- a/nodejs/scripts/build.sh
+++ b/nodejs/scripts/build.sh
@@ -1,14 +1,17 @@
 set -e
 
+cd "$(dirname "$0")/.."
+echo "Running in $(pwd)"
+
 VERSION=$(node -p "require('./package.json').version")
 echo "Building version $VERSION"
 
 # Some bundlers (Vite+Remix) make it harder to import JSON
 # Because of this, this hack is implemented, substituting the version file
-echo Materializing version file
+echo "Materializing version file"
 echo "export const VERSION = \"$VERSION\";" > src/version_dist.ts
 
-echo Compiling package...
+echo "Compiling package..."
 
 rm -rf lib > /dev/null 2>&1
 tsc -p tsconfig.json --module nodenext --outDir lib/esm
@@ -17,26 +20,26 @@ echo "{\"type\": \"module\", \"version\": \"$VERSION\"}" > lib/esm/package.json
 tsc -p tsconfig.cjs.json --module commonjs --outDir lib/cjs
 echo "{\"type\": \"commonjs\", \"version\": \"$VERSION\"}" > lib/cjs/package.json
 
-echo Compilation successful!
+echo "Compilation successful!"
 
 # After building the package, replace version.ts importing from package.json with the "static" version
-echo Substituting materialized version export
+echo "Substituting materialized version export"
 
 mv lib/cjs/src/version_dist.js lib/cjs/src/version.js
 mv lib/cjs/src/version_dist.js.map lib/cjs/src/version.js.map
 rm lib/cjs/src/version_dist.d.ts
-sed -i '' 's/version_dist.js/version.js/g' lib/cjs/src/version.js.map
-sed -i '' 's/version_dist.js.map/version.js.map/g' lib/cjs/src/version.js
+node scripts/subst.js 'version_dist.js' 'version.js' lib/cjs/src/version.js.map
+node scripts/subst.js 'version_dist.js.map' 'version.js.map' lib/cjs/src/version.js
 
 mv lib/esm/src/version_dist.js lib/esm/src/version.js
 mv lib/esm/src/version_dist.js.map lib/esm/src/version.js.map
 rm lib/esm/src/version_dist.d.ts
-sed -i '' 's/version_dist.js/version.js/g' lib/esm/src/version.js.map
-sed -i '' 's/version_dist.js.map/version.js.map/g' lib/esm/src/version.js
+node scripts/subst.js 'version_dist.js' 'version.js' lib/esm/src/version.js.map
+node scripts/subst.js 'version_dist.js.map' 'version.js.map' lib/esm/src/version.js
 
-echo Cleaning up...
+echo "Cleaning up..."
 
 rm -rf lib/{cjs,esm}/**/{*.test.*,test-helper.*} > /dev/null 2>&1
 rm -rf lib/{cjs,esm}/*.tsbuildinfo > /dev/null 2>&1
 
-echo All done
+echo "All done."

--- a/nodejs/scripts/build.sh
+++ b/nodejs/scripts/build.sh
@@ -3,7 +3,12 @@ set -e
 VERSION=$(node -p "require('./package.json').version")
 echo "Building version $VERSION"
 
-echo Compiling...
+# Some bundlers (Vite+Remix) make it harder to import JSON
+# Because of this, this hack is implemented, substituting the version file
+echo Materializing version file
+echo "export const VERSION = \"$VERSION\";" > src/version_dist.ts
+
+echo Compiling package...
 
 rm -rf lib > /dev/null 2>&1
 tsc -p tsconfig.json --module nodenext --outDir lib/esm
@@ -14,6 +19,16 @@ echo "{\"type\": \"commonjs\", \"version\": \"$VERSION\"}" > lib/cjs/package.jso
 
 echo Compilation successful!
 
+# After building the package, replace version.ts importing from package.json with the "static" version
+echo Substituting materialized version export
+mv lib/cjs/src/version_dist.js lib/cjs/src/version.js
+mv lib/cjs/src/version_dist.js.map lib/cjs/src/version.js.map
+rm lib/cjs/src/version_dist.d.ts
+mv lib/esm/src/version_dist.js lib/esm/src/version.js
+mv lib/esm/src/version_dist.js.map lib/esm/src/version.js.map
+rm lib/esm/src/version_dist.d.ts
+
 echo Cleaning up...
 
 rm -rf lib/{cjs,esm}/**/{*.test.*,test-helper.*,*.tsbuildinfo} > /dev/null 2>&1
+rm -rf lib/{cjs,esm}/*.tsbuildinfo > /dev/null 2>&1

--- a/nodejs/scripts/subst.js
+++ b/nodejs/scripts/subst.js
@@ -1,0 +1,9 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const [from, to, file] = process.argv.slice(2);
+const filePath = path.resolve(process.cwd(), file);
+
+const input = fs.readFileSync(filePath, "utf-8");
+const output = input.replaceAll(from, to);
+fs.writeFileSync(filePath, output, "utf-8");

--- a/nodejs/src/fetch.ts
+++ b/nodejs/src/fetch.ts
@@ -1,4 +1,4 @@
-import packageJson from "../package.json";
+import { VERSION } from "./version.js";
 
 import type {
 	AudioSpeechFormat,
@@ -44,7 +44,7 @@ export const queryAPI = async ({
 	headers.set("Authorization", `Bearer ${token}`);
 
 	headers.set("X-Speechify-SDK", "nodejs");
-	headers.set("X-Speechify-SDK-Version", packageJson.version);
+	headers.set("X-Speechify-SDK-Version", VERSION);
 
 	if (jsonPayload) {
 		options.body = JSON.stringify(jsonPayload);

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -21,6 +21,7 @@ import type {
 	AccessTokenGetter,
 	SpeechifyAccessTokenManagerOptions,
 } from "./types.js";
+import { VERSION } from "./version.js";
 
 export type { SpeechifyError } from "./fetch.js";
 export type {
@@ -126,6 +127,13 @@ export class Speechify {
 	}
 
 	/**
+	 * Get the current version of the package
+	 */
+	get version() {
+		return VERSION;
+	}
+
+	/**
 	 * Set the [access token](https://docs.sws.speechify.com/docs/authentication#access-tokens) for the client.
 	 * @param token The Access Token to set.
 	 */
@@ -201,7 +209,7 @@ export class Speechify {
 		})) as VoicesListResponseServer;
 
 		return response.map(
-			mapVoice
+			mapVoice,
 		) satisfies VoicesListResponse as VoicesListResponse;
 	}
 
@@ -216,7 +224,7 @@ export class Speechify {
 		formData.set("name", req.name);
 		formData.set(
 			"sample",
-			req.sample instanceof Buffer ? new Blob([req.sample]) : req.sample
+			req.sample instanceof Buffer ? new Blob([req.sample]) : req.sample,
 		);
 		formData.set("consent", JSON.stringify(req.consent));
 
@@ -389,7 +397,7 @@ export class SpeechifyAccessTokenManager {
 	constructor(
 		speechifyClient: Speechify,
 		getToken: AccessTokenGetter,
-		options: SpeechifyAccessTokenManagerOptions = {}
+		options: SpeechifyAccessTokenManagerOptions = {},
 	) {
 		const { isAuthenticated = false } = options;
 
@@ -445,8 +453,11 @@ export class SpeechifyAccessTokenManager {
 			throw new Error("Token expiration time is missing");
 		}
 
-		setTimeout(() => {
-			this.#refreshToken();
-		}, (expiresIn / 2) * 1000);
+		setTimeout(
+			() => {
+				this.#refreshToken();
+			},
+			(expiresIn / 2) * 1000,
+		);
 	}
 }

--- a/nodejs/src/test-helper.mjs
+++ b/nodejs/src/test-helper.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { test, describe, expect, beforeAll } from "vitest";
+import packageJson from "../package.json";
 
 export default function testSuite(Speechify, SpeechifyAccessTokenManager) {
 	let speechify;
@@ -33,8 +34,8 @@ export default function testSuite(Speechify, SpeechifyAccessTokenManager) {
 			const file = fs.readFileSync(
 				path.resolve(
 					import.meta.dirname,
-					"./test-fixtures/donald-duck-america.mp3"
-				)
+					"./test-fixtures/donald-duck-america.mp3",
+				),
 			);
 
 			const blob = new Blob([file], { type: "audio/mpeg" });
@@ -58,8 +59,8 @@ export default function testSuite(Speechify, SpeechifyAccessTokenManager) {
 			const file = fs.readFileSync(
 				path.resolve(
 					import.meta.dirname,
-					"./test-fixtures/donald-duck-america.mp3"
-				)
+					"./test-fixtures/donald-duck-america.mp3",
+				),
 			);
 
 			const voice = await speechify.voicesCreate({
@@ -81,8 +82,8 @@ export default function testSuite(Speechify, SpeechifyAccessTokenManager) {
 			const file = fs.readFileSync(
 				path.resolve(
 					import.meta.dirname,
-					"./test-fixtures/donald-duck-america.mp3"
-				)
+					"./test-fixtures/donald-duck-america.mp3",
+				),
 			);
 
 			const voice = await speechify.voicesCreate({
@@ -148,7 +149,7 @@ export default function testSuite(Speechify, SpeechifyAccessTokenManager) {
 			speechify.setAccessToken(token.accessToken);
 
 			await expect(speechify.voicesList()).rejects.toThrowError(
-				/none of the sufficient scopes found/
+				/none of the sufficient scopes found/,
 			);
 
 			speechify.setAccessToken(undefined);
@@ -197,6 +198,12 @@ export default function testSuite(Speechify, SpeechifyAccessTokenManager) {
 			});
 
 			expect(stream).toBeInstanceOf(ReadableStream);
+		});
+	});
+
+	describe("version", () => {
+		test("returns the current package version", () => {
+			expect(speechify.version).toBe(packageJson.version);
 		});
 	});
 

--- a/nodejs/src/version.ts
+++ b/nodejs/src/version.ts
@@ -1,0 +1,3 @@
+import packageJson from "../package.json";
+
+export const VERSION = packageJson.version;

--- a/nodejs/src/version.ts
+++ b/nodejs/src/version.ts
@@ -1,3 +1,6 @@
+// NB! During build, this module is removed from the dist folders and replaced
+// with the variant returning the static version read from package.json
+// at _build_ time. Refer to `scripts/build.sh`
 import packageJson from "../package.json";
 
 export const VERSION = packageJson.version;


### PR DESCRIPTION
Vite+Remix fail when there's an import from JSON without [import type assertion](https://v8.dev/features/import-assertions). At the same time, I don't want to mess with it as it may break TS or require extra configuration for other bundlers.

As a solution, at build time I create a separate module with the exact version copied from package.json, and do some hacky manipulations to substitute the original version.ts (reading from package.json) with the static version in the dist folder