### PR TITLE
chore: put default field at the last place in exports to avoid build issue in Nextjs projects

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -11,12 +11,12 @@
 	"exports": {
 		".": {
 			"require": {
-				"default": "./lib/cjs/src/index.js",
-				"types": "./lib/cjs/src/index.d.ts"
+				"types": "./lib/cjs/src/index.d.ts",
+				"default": "./lib/cjs/src/index.js"
 			},
 			"import": {
-				"default": "./lib/esm/src/index.js",
-				"types": "./lib/esm/src/index.d.ts"
+				"types": "./lib/esm/src/index.d.ts",
+				"default": "./lib/esm/src/index.js"
 			}
 		}
 	},


### PR DESCRIPTION
Currently SDK build fails in Next.js projects due to webpack issue
The issue is resolved by always putting default field in exports in the last place